### PR TITLE
Always include explicitly mapped attribute from Base::$mapToSlot

### DIFF
--- a/src/Components/Base.php
+++ b/src/Components/Base.php
@@ -146,7 +146,9 @@ abstract class Base extends Component
                     $collection = new SlotCollection();
 
                     foreach ($viewData[$property] as $key => $item) {
-                        $attributes = !is_numeric($key) ? [$keyName => $key] : [];
+                        $attributes = (!is_numeric($key) || $keyName === $keyFieldName)
+                            ? [$keyName => $key]
+                            : [];
 
                         $collection->push(new ComponentSlot($item, $attributes));
                     }

--- a/tests/Feature/Components/Form/SelectTest.php
+++ b/tests/Feature/Components/Form/SelectTest.php
@@ -95,6 +95,39 @@ class SelectTest extends FeatureTestCase
                 ),
             ],
             [
+                'view' => 'form.select.general',
+                'data' => [
+                    'label'   => $label,
+                    'name'    => $name,
+                    'id'      => $id,
+                    'options' => array_values($options),
+                    'value'   => $value,
+                ],
+                'expects' => array_merge(
+                    [
+                        '<div class="mb-3">',
+                        sprintf('<label for="%s" class="form-label">%s</label>', $id, $label),
+                        sprintf('<select class="form-control" id="%s" name="%s">', $id, $name),
+                    ],
+                    array_map(
+                        function ($word, $key) use ($value) {
+                            return sprintf(
+                                '<option value="%s"%s>%s</option>',
+                                $key,
+                                ($key === $value) ? ' selected' : '',
+                                $word
+                            );
+                        },
+                        $options,
+                        array_keys(array_values($options))
+                    ),
+                    [
+                        '</select>',
+                        '</div>',
+                    ]
+                ),
+            ],
+            [
                 'view' => 'form.select.general_slots',
                 'data' => [
                     'label'   => $label,

--- a/tests/Unit/Components/BaseTest.php
+++ b/tests/Unit/Components/BaseTest.php
@@ -6,6 +6,7 @@ use Avastechnology\Iolaus\Traits\InvokeMethod;
 use Avastechnology\Iolaus\Traits\InvokeSetter;
 use Illuminate\View\ComponentSlot;
 use PHPUnit\Framework\MockObject\Exception;
+use StoneHilt\Blade\View\SlotCollection;
 use StoneHilt\Bootstrap\Components\Base;
 use StoneHilt\Bootstrap\Tests\Unit\UnitTestCase;
 
@@ -88,6 +89,90 @@ class BaseTest extends UnitTestCase
                 'expected' => [
                     'a' => 'abc',
                     'title' => new ComponentSlot('The title', ['x'=> 'X']),
+                    'b' => 2.5
+                ],
+            ],
+            [
+                'viewData' => [
+                    'a' => 'abc',
+                    'title' => [
+                        'title_a' => 'Title A',
+                        'title_b' => 'Title B',
+                    ],
+                    'b' => 2.5
+                ],
+                'mapToSlot' => ['title'],
+                'expected' => [
+                    'a' => 'abc',
+                    'title' => new SlotCollection(
+                        [
+                            new ComponentSlot('Title A', ['id'=> 'title_a']),
+                            new ComponentSlot('Title B', ['id'=> 'title_b']),
+                        ]
+                    ),
+                    'b' => 2.5
+                ],
+            ],
+            [
+                'viewData' => [
+                    'a' => 'abc',
+                    'title' => [
+                        'title_a' => 'Title A',
+                        'title_b' => 'Title B',
+                    ],
+                    'b' => 2.5
+                ],
+                'mapToSlot' => ['title' => 'attr'],
+                'expected' => [
+                    'a' => 'abc',
+                    'title' => new SlotCollection(
+                        [
+                            new ComponentSlot('Title A', ['attr'=> 'title_a']),
+                            new ComponentSlot('Title B', ['attr'=> 'title_b']),
+                        ]
+                    ),
+                    'b' => 2.5
+                ],
+            ],
+            [
+                'viewData' => [
+                    'a' => 'abc',
+                    'title' => [
+                        2 => 'Title A',
+                        10 => 'Title B',
+                    ],
+                    'b' => 2.5
+                ],
+                'mapToSlot' => ['title'],
+                'expected' => [
+                    'a' => 'abc',
+                    'title' => new SlotCollection(
+                        [
+                            new ComponentSlot('Title A'),
+                            new ComponentSlot('Title B'),
+                        ]
+                    ),
+                    'b' => 2.5
+                ],
+            ],
+            [
+                'viewData' => [
+                    'a' => 'abc',
+                    'title' => [
+                        2 => 'Title A',
+                        10 => 'Title B',
+                    ],
+                    'b' => 2.5
+                ],
+                'mapToSlot' => ['title' => 'attr'],
+                'expected' => [
+                    'a' => 'abc',
+                    'title' => new SlotCollection(
+                        [
+                            new ComponentSlot('Title A', ['attr'=> 2]),
+                            new ComponentSlot('Title B', ['attr'=> 10]),
+                        ]
+                    ),
                     'b' => 2.5
                 ],
             ],


### PR DESCRIPTION
When there is an explicitly mapped attribute in Base::$mapToSlot, always include it no matter if the key is numeric.